### PR TITLE
Add actix-web support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,15 @@ version = "0.2.0"
 
 [dependencies]
 gettext = "0.3"
-rocket = "0.4.0-rc.1"
+
+[dependencies.rocket]
+version = "0.4.0-rc.1"
+optional = true
+
+[dependencies.actix-web]
+version = "0.7"
+optional = true
 
 [features]
+default = ["rocket"]
 build = []

--- a/README.md
+++ b/README.md
@@ -85,3 +85,46 @@ msgid_plural "You have {{ count }} new notifications" # The plural one
 msgstr[0] ""
 msgstr[1] ""
 ```
+
+### Using with Actix Web
+
+First, disable the default features so it doesn't pull in all of Rocket.
+```toml
+[dependencies.rocket_i18n]
+version = "0.2"
+default-features = false
+features = ["actix-web"]
+```
+
+Then add it to your application.
+```rust
+#[macro_use]
+extern crate rocket_i18n;
+
+use rocket_i18n::{I18n, Internationalized, Translations};
+
+fn route_handler(i18n: I18n) -> &str {
+    i18n!(i18n.catalog, "Hello, world!")
+}
+
+#[derive(Clone)]
+struct MyState {
+    translations: Translations,
+}
+
+impl Internationalized for MyState {
+    fn get(&self) -> Translations {
+        self.translations.clone()
+    }
+}
+
+fn main() {
+    let state = MyState {
+        translations: rocket_i18n::i18n(vec![ "en", "fr", "de", "ja" ]);
+    };
+
+    App::with_state(state)
+        .resource("", |r| r.with(route_handler))
+        .finish();
+}
+```

--- a/src/with_actix.rs
+++ b/src/with_actix.rs
@@ -1,0 +1,64 @@
+use std::{error::Error, fmt};
+
+use crate::{I18n, Translations, ACCEPT_LANG};
+
+use actix_web::{FromRequest, HttpRequest, ResponseError};
+
+#[derive(Debug)]
+pub struct MissingTranslationsError(String);
+
+impl fmt::Display for MissingTranslationsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Could not find translations for {}", self.0)
+    }
+}
+
+impl Error for MissingTranslationsError {
+    fn description(&self) -> &str {
+        "Could not find translations"
+    }
+}
+
+impl ResponseError for MissingTranslationsError {
+    // this defaults to an empty InternalServerError response
+}
+
+pub trait Internationalized {
+    fn get(&self) -> Translations;
+}
+
+impl<S> FromRequest<S> for I18n
+where
+    S: Internationalized,
+{
+    type Config = ();
+    type Result = Result<Self, actix_web::Error>;
+
+    fn from_request(req: &HttpRequest<S>, _: &Self::Config) -> Self::Result {
+        let state = req.state();
+        let langs = state.get();
+
+        let lang = req
+            .headers()
+            .get(ACCEPT_LANG)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("en")
+            .split(",")
+            .filter_map(|lang| {
+                lang
+                    // Get the locale, not the country code
+                    .split(|c| c == '-' || c == ';')
+                    .nth(0)
+            })
+            // Get the first requested locale we support
+            .find(|lang| langs.iter().any(|l| l.0 == &lang.to_string()))
+            .unwrap_or("en");
+
+        match langs.iter().find(|l| l.0 == lang) {
+            Some(catalog) => Ok(I18n {
+                catalog: catalog.1.clone(),
+            }),
+            None => Err(MissingTranslationsError(lang.to_owned()).into()),
+        }
+    }
+}

--- a/src/with_rocket.rs
+++ b/src/with_rocket.rs
@@ -1,0 +1,37 @@
+use crate::{ACCEPT_LANG, I18n, Translations};
+
+use rocket::{
+    http::Status,
+    request::{self, FromRequest},
+    Outcome, Request, State,
+};
+
+impl<'a, 'r> FromRequest<'a, 'r> for I18n{
+    type Error = ();
+
+    fn from_request(req: &'a Request) -> request::Outcome<I18n, ()> {
+        let langs = &*req
+            .guard::<State<Translations>>()
+            .expect("Couldn't retrieve translations because they are not managed by Rocket.");
+
+        let lang = req
+            .headers()
+            .get_one(ACCEPT_LANG)
+            .unwrap_or("en")
+            .split(",")
+            .filter_map(|lang| lang
+                // Get the locale, not the country code
+                .split(|c| c == '-' || c == ';')
+                .nth(0))
+            // Get the first requested locale we support
+            .find(|lang| langs.iter().any(|l| l.0 == &lang.to_string()))
+            .unwrap_or("en");
+
+        match langs.iter().find(|l| l.0 == lang) {
+            Some(catalog) => Outcome::Success(I18n {
+                catalog: catalog.1.clone(),
+            }),
+            None => Outcome::Failure((Status::InternalServerError, ())),
+        }
+    }
+}


### PR DESCRIPTION
This splits the rocket-specific code into it's own file, and adds an additional file for actix support. It also creates a "rocket" feature, which is enabled by default, and an "actix-web" features, which is disabled by default.