### PR TITLE
 Add new macro importing translation to the final binary 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,27 @@ pub fn i18n(domain: &str, lang: Vec<&'static str>) -> Translations {
     })
 }
 
+#[macro_export]
+macro_rules! include_i18n {
+    ( $domain:tt, [$($lang:tt),*] ) => {
+        {
+            use $crate::Catalog;
+            vec![
+            $(
+                (
+                    $lang,
+                    Catalog::parse(
+                        &include_bytes!(
+                            concat!(env!("CARGO_MANIFEST_DIR"), "/translations/", $lang, "/LC_MESSAGES/", $domain, ".mo")
+                            )[..]
+                        ).expect("Error while loading catalog")
+                )
+            ),*
+            ]
+        }
+    }
+}
+
 #[cfg(feature = "build")]
 pub fn update_po(domain: &str, locales: &[&'static str]) {
     use std::{path::Path, process::Command};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,15 @@ pub fn i18n(domain: &str, lang: Vec<&'static str>) -> Translations {
     })
 }
 
+/// Use this macro to staticaly import translations into your final binary. It's use is similar to
+/// [`i18n`](../rocket_i18n/fn.i18n.html)
+/// ```rust,ignore
+/// # //ignore because there is no translation file provided with rocket_i18n
+/// # #[macro_use]
+/// # extern crate rocket_i18n;
+/// # use rocket_i18n::Translations;
+/// let tr: Translations = include_i18n!("plume", ["de", "en", "fr"]);
+/// ```
 #[macro_export]
 macro_rules! include_i18n {
     ( $domain:tt, [$($lang:tt),*] ) => {


### PR DESCRIPTION
Add a new macro `include_i18n!`, taking similar arguments to `i18n()`, and expanding to the same type. It allow to include translations in the final binary, so that once compiled, it can be run from anywhere,
without depending on `.mo`s to be present